### PR TITLE
Fix idle callback fallback

### DIFF
--- a/store/useFeedStore.ts
+++ b/store/useFeedStore.ts
@@ -474,7 +474,11 @@ export const useFeedStore = create<FeedState>()(
             }
             
             // Initialize worker service after hydration
-            requestIdleCallback(() => {
+            const idleCallback =
+              typeof window !== "undefined" && window.requestIdleCallback
+                ? window.requestIdleCallback
+                : (cb: () => void) => setTimeout(cb, 0);
+            idleCallback(() => {
               workerService.initialize();
             });
           } catch (error) {


### PR DESCRIPTION
## Summary
- ensure `window.requestIdleCallback` exists before using it
- fall back to `setTimeout` when necessary

## Testing
- `pnpm lint` *(fails: connect EHOSTUNREACH)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved compatibility across different environments by ensuring background tasks run smoothly even when certain browser features are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->