### PR TITLE
Reduce toast removal delay

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,8 @@ pnpm build
 pnpm start
 ```
 You can also deploy to platforms like Vercel using their standard Next.js workflow.
+
+## Toast notifications
+The custom `useToast` hook automatically removes dismissed toasts after five
+seconds. You can adjust this delay by editing `TOAST_REMOVE_DELAY` in
+`hooks/use-toast.ts`.

--- a/hooks/use-toast.ts
+++ b/hooks/use-toast.ts
@@ -9,7 +9,9 @@ import type {
 } from "@/components/ui/toast"
 
 const TOAST_LIMIT = 1
-const TOAST_REMOVE_DELAY = 1000000
+// Delay before a dismissed toast is removed from state
+// Default is 5 seconds which is typical for toast notifications
+const TOAST_REMOVE_DELAY = 5000
 
 type ToasterToast = ToastProps & {
   id: string


### PR DESCRIPTION
## Summary
- keep toast remove logic but use a more reasonable delay
- document how to change the delay

## Testing
- `pnpm lint` *(fails: connect EHOSTUNREACH 172.25.0.3:8080)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a section to the README explaining toast notification behavior and how to customize the dismissal delay.

- **Refactor**
  - Updated the default removal delay for dismissed toast notifications from approximately 16.7 minutes to 5 seconds for a more typical user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->