### PR TITLE
Add TTS option with settings

### DIFF
--- a/app/web/settings/components/tabs/api-settings-tab.tsx
+++ b/app/web/settings/components/tabs/api-settings-tab.tsx
@@ -5,6 +5,8 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { useTtsSettingsStore, TtsProvider } from "@/store/useTtsSettingsStore"
 import { useApiConfigStore } from "@/store/useApiConfigStore"
 import { DEFAULT_API_CONFIG } from "@/lib/config"
 import { workerService } from "@/services/worker-service"
@@ -18,6 +20,14 @@ export function ApiSettingsTab() {
   const [connectionStatus, setConnectionStatus] = useState<
     { success: boolean; message: string } | null
   >(null);
+
+  const { provider, apiKeys, setProvider, setApiKey } = useTtsSettingsStore();
+  const [selectedProvider, setSelectedProvider] = useState<TtsProvider>(provider);
+  const [ttsKey, setTtsKey] = useState(apiKeys[provider] || "");
+
+  useEffect(() => {
+    setTtsKey(apiKeys[selectedProvider] || "");
+  }, [selectedProvider, apiKeys]);
 
   // Initialize input field when component mounts
   useEffect(() => {
@@ -95,7 +105,13 @@ export function ApiSettingsTab() {
     });
   };
 
+  const saveTtsSettings = () => {
+    setProvider(selectedProvider);
+    setApiKey(selectedProvider, ttsKey);
+  };
+
   return (
+    <>
     <Card>
       <CardHeader>
         <CardTitle>API Settings</CardTitle>
@@ -172,5 +188,44 @@ export function ApiSettingsTab() {
         )}
       </CardContent>
     </Card>
+    <Card className="mt-6">
+      <CardHeader>
+        <CardTitle>Text-to-Speech</CardTitle>
+        <CardDescription>Select your preferred TTS engine</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="space-y-2">
+          <Label htmlFor="tts-provider">Engine</Label>
+          <Select
+            value={selectedProvider}
+            onValueChange={(val) => setSelectedProvider(val as TtsProvider)}
+          >
+            <SelectTrigger id="tts-provider" className="w-[180px]">
+              <SelectValue placeholder="Select engine" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="edge">Edge</SelectItem>
+              <SelectItem value="gemini">Gemini</SelectItem>
+              <SelectItem value="openai">OpenAI</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+        {selectedProvider !== 'edge' && (
+          <div className="space-y-2">
+            <Label htmlFor="tts-key">API Key</Label>
+            <Input
+              id="tts-key"
+              value={ttsKey}
+              onChange={(e) => setTtsKey(e.target.value)}
+            />
+            <p className="text-sm text-muted-foreground">
+              Key is stored locally on this device
+            </p>
+          </div>
+        )}
+        <Button onClick={saveTtsSettings}>Save TTS Settings</Button>
+      </CardContent>
+    </Card>
+    </>
   );
 }

--- a/components/Feed/ArticleReader/ArticleReader.tsx
+++ b/components/Feed/ArticleReader/ArticleReader.tsx
@@ -4,12 +4,13 @@ import { memo, useEffect, useMemo, useState } from "react";
 import Image from "next/image";
 import { FeedItem, ReaderViewResponse } from "@/types";
 import { Skeleton } from "@/components/ui/skeleton";
-import { Share2, ExternalLink, Bookmark } from "lucide-react";
+import { Share2, ExternalLink, Bookmark, Volume2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { cleanupModalContent } from "@/utils/htmlUtils";
 import { useFeedStore } from "@/store/useFeedStore";
 import { toast } from "sonner";
 import { useIsMobile } from "@/hooks/use-media-query";
+import { useTTS } from "@/hooks/use-tts";
 
 export const ArticleImage = memo(({ 
   src, 
@@ -90,6 +91,7 @@ export const ArticleHeader = memo(({
 }) => {
   const isModal = layout === "modal";
   const isCompact = layout === "compact";
+  const { speak } = useTTS();
   const { addToReadLater, removeFromReadLater, isInReadLater } = useFeedStore();
   const [isInReadLaterList, setIsInReadLaterList] = useState(false);
 
@@ -134,6 +136,11 @@ export const ArticleHeader = memo(({
         description: "The article has been added to your reading list.",
       });
     }
+  };
+
+  const handleTts = () => {
+    const text = readerView?.textContent || feedItem.description || "";
+    speak(text);
   };
 
   return (
@@ -182,17 +189,25 @@ export const ArticleHeader = memo(({
                 >
                   <Bookmark className={`h-4 w-4 ${isInReadLaterList ? "fill-red-500 text-red-500" : ""}`} />
                 </Button>
-                <Button 
-                  size="icon" 
-                  variant="ghost" 
+                <Button
+                  size="icon"
+                  variant="ghost"
                   onClick={handleShare}
                   className="h-8 w-8"
                 >
                   <Share2 className="h-4 w-4" />
                 </Button>
-                <Button 
-                  size="icon" 
-                  variant="ghost" 
+                <Button
+                  size="icon"
+                  variant="ghost"
+                  onClick={handleTts}
+                  className="h-8 w-8"
+                >
+                  <Volume2 className="h-4 w-4" />
+                </Button>
+                <Button
+                  size="icon"
+                  variant="ghost"
                   asChild
                   className="h-8 w-8"
                 >
@@ -221,13 +236,17 @@ export const ArticleHeader = memo(({
               {/* Actions */}
               {actions || (
                 <div className="flex gap-2">
-                  <Button 
-                    size="sm" 
-                    variant="ghost" 
+                  <Button
+                    size="sm"
+                    variant="ghost"
                     onClick={handleReadLater}
                   >
                     <Bookmark className={`h-4 w-4 mr-1 ${isInReadLaterList ? "fill-red-500 text-red-500" : ""}`} />
                     {isInReadLaterList ? "Read Later" : "Read Later"}
+                  </Button>
+                  <Button size="sm" variant="ghost" onClick={handleTts}>
+                    <Volume2 className="h-4 w-4 mr-1" />
+                    Listen
                   </Button>
                   <Button size="sm" variant="ghost" onClick={handleShare}>
                     <Share2 className="h-4 w-4 mr-1" />

--- a/hooks/use-tts.ts
+++ b/hooks/use-tts.ts
@@ -1,0 +1,31 @@
+import { useCallback } from "react";
+import { useTtsSettingsStore } from "@/store/useTtsSettingsStore";
+
+export function useTTS() {
+  const { provider } = useTtsSettingsStore();
+
+  const speak = useCallback(
+    (text: string) => {
+      if (!text) return;
+      switch (provider) {
+        case "edge":
+        default:
+          if (typeof window !== "undefined" && "speechSynthesis" in window) {
+            const utterance = new SpeechSynthesisUtterance(text);
+            window.speechSynthesis.cancel();
+            window.speechSynthesis.speak(utterance);
+          }
+          break;
+      }
+    },
+    [provider]
+  );
+
+  const cancel = useCallback(() => {
+    if (typeof window !== "undefined" && "speechSynthesis" in window) {
+      window.speechSynthesis.cancel();
+    }
+  }, []);
+
+  return { speak, cancel };
+}

--- a/store/useTtsSettingsStore.ts
+++ b/store/useTtsSettingsStore.ts
@@ -1,0 +1,35 @@
+import { create } from "zustand";
+import { persist, createJSONStorage } from "zustand/middleware";
+import localforage from "localforage";
+
+export type TtsProvider = "edge" | "gemini" | "openai";
+
+interface TtsSettingsState {
+  provider: TtsProvider;
+  apiKeys: Record<string, string>;
+  setProvider: (provider: TtsProvider) => void;
+  setApiKey: (provider: TtsProvider, key: string) => void;
+}
+
+const DEFAULT_SETTINGS: TtsSettingsState = {
+  provider: "edge",
+  apiKeys: {},
+  setProvider: () => {},
+  setApiKey: () => {},
+};
+
+export const useTtsSettingsStore = create<TtsSettingsState>()(
+  persist(
+    (set, get) => ({
+      provider: "edge",
+      apiKeys: {},
+      setProvider: (provider) => set({ provider }),
+      setApiKey: (provider, key) =>
+        set({ apiKeys: { ...get().apiKeys, [provider]: key } }),
+    }),
+    {
+      name: "digests-tts-settings",
+      storage: createJSONStorage(() => localforage),
+    }
+  )
+);


### PR DESCRIPTION
## Summary
- implement a Zustand store for text-to-speech preferences
- add a hook that speaks using browser speech synthesis
- expose Listen button in article header
- allow choosing TTS engine and API key in settings

## Testing
- `node scripts/pretest.js`
- `node --test tests/*.js`
- `npx eslint . --max-warnings=0` *(fails: Cannot find package '@eslint/eslintrc')*
- `npx tsc --noEmit` *(fails: cannot find many modules)*