### PR TITLE
fix: conditionally render ReactQueryDevtools based on environment

### DIFF
--- a/components/providers/query-provider.tsx
+++ b/components/providers/query-provider.tsx
@@ -19,6 +19,13 @@ interface QueryProviderProps {
   children: React.ReactNode
 }
 
+/**
+ * Provides a React Query context and optionally includes React Query Devtools in development environments.
+ *
+ * Wraps child components with a {@link QueryClientProvider}, supplying a query client instance for React Query state management. In development mode, also renders the {@link ReactQueryDevtools} panel.
+ *
+ * @param children - The React elements to be rendered within the provider.
+ */
 export function QueryProvider({ children }: QueryProviderProps) {
   // Create a new QueryClient instance for this provider
   const [queryClient] = useState(() => getQueryClient())


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the app to display React Query Devtools only in development mode, ensuring it is hidden in production and other environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->