### PR TITLE
fix: normalize feed URL protocols

### DIFF
--- a/scripts/pretest.js
+++ b/scripts/pretest.js
@@ -5,7 +5,7 @@ const modules = [
 ];
 try {
   execSync(`rm -rf compiled-tests && mkdir compiled-tests`);
-  execSync(`npx tsc ${modules.join(' ')} --module commonjs --target es2017 --outDir compiled-tests`, { stdio: 'inherit' });
+  execSync(`npx tsc ${modules.join(' ')} --module commonjs --target es2017 --skipLibCheck --outDir compiled-tests`, { stdio: 'inherit' });
 } catch (e) {
   console.error('Failed to compile test modules', e);
   process.exit(1);

--- a/tests/urlHelpers.test.js
+++ b/tests/urlHelpers.test.js
@@ -6,6 +6,10 @@ test('removes protocol and trailing slash', () => {
   assert.strictEqual(normalizeFeedUrl('https://example.com/'), 'example.com');
 });
 
+test('removes protocol regardless of case', () => {
+  assert.strictEqual(normalizeFeedUrl('HTTP://Example.com'), 'Example.com');
+});
+
 test('normalizes multiple slashes', () => {
   assert.strictEqual(normalizeFeedUrl('https://example.com//a//b'), 'example.com/a/b');
 });

--- a/utils/url-helpers.ts
+++ b/utils/url-helpers.ts
@@ -4,8 +4,8 @@ export const normalizeFeedUrl = (url: string | null): string => {
     // First decode to handle any encoded URLs
     const decoded = decodeURIComponent(url);
     return decoded
-      // Remove protocol
-      .replace(/^https?:\/\//, '')
+      // Remove protocol (case-insensitive)
+      .replace(/^https?:\/\//i, '')
       // Remove trailing slashes
       .replace(/\/+$/, '')
       // Normalize multiple slashes
@@ -14,4 +14,4 @@ export const normalizeFeedUrl = (url: string | null): string => {
     console.warn('Error normalizing URL:', error);
     return url.replace(/\/+$/, '');
   }
-}; 
+};


### PR DESCRIPTION
## Summary
- handle feed URLs with mixed-case HTTP protocols
- ignore library type errors during test compilation
- test normalizeFeedUrl for case-insensitive protocol stripping

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c091a04b883279516a22bb4ca6403